### PR TITLE
Add XHR Headers Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ function DownloaderSuccess() {
 | `timeout`     | `0`                          | Download timeout in milliseconds. Set to 0 for infinite time|
 | `success`     | `undefined`                  | Success callback|
 | `error`       | `undefined`                  | Error callback. Argument indicates problem|
-| `headers`     | `undefined`                  | Set XHR Headers. Accepts a list Key/Value pairs. `[{Key: 'Authorization', Value: 'Basic xxxxxxx'}]`|
+| `headers`     | `[]`                         | Set XHR Headers. Accepts a list Key/Value pairs. `[{Key: 'Authorization', Value: 'Basic xxxxxxx'}]`|
 
 
 ## Error Codes

--- a/README.md
+++ b/README.md
@@ -32,7 +32,13 @@ dl.Initialize({
     remove: true,
     timeout: 0,
     success: DownloaderSuccess,
-    error: DownloaderError
+    error: DownloaderError,
+    headers: [
+        {
+            Key: 'Authorization',
+            Value: 'Basic ' + btoa(token)
+        }
+    ]
 });
 
 
@@ -61,6 +67,7 @@ function DownloaderSuccess() {
 | `timeout`     | `0`                          | Download timeout in milliseconds. Set to 0 for infinite time|
 | `success`     | `undefined`                  | Success callback|
 | `error`       | `undefined`                  | Error callback. Argument indicates problem|
+| `headers`     | `undefined`                  | Set XHR Headers. Accepts a list Key/Value pairs. `[{Key: 'Authorization', Value: 'Basic xxxxxxx'}]`|
 
 
 ## Error Codes

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ function DownloaderSuccess() {
 | `timeout`     | `0`                          | Download timeout in milliseconds. Set to 0 for infinite time|
 | `success`     | `undefined`                  | Success callback|
 | `error`       | `undefined`                  | Error callback. Argument indicates problem|
-| `headers`     | `[]`                         | Set XHR Headers. Accepts a list Key/Value pairs. `[{Key: 'Authorization', Value: 'Basic xxxxxxx'}]`|
+| `headers`     | `[]`                         | Set XHR Headers. Accepts a list of Key/Value pairs. `[{Key: 'Authorization', Value: 'Basic xxxxxxx'}]`|
 
 
 ## Error Codes

--- a/www/download.js
+++ b/www/download.js
@@ -7,7 +7,7 @@ function Download() {
         unzip: false,
         remove: false,
         timeout: 0,
-        headers: {}
+        headers: []
     };
 }
 
@@ -81,7 +81,9 @@ Download.prototype.Get = function(url) {
 
         var xhr = new XMLHttpRequest();
         xhr.open('GET', url, true);
-        xhr.setRequestHeader('Authorization', that.Settings.headers.Authorization);
+        that.Settings.headers.forEach(function(header){
+            xhr.setRequestHeader(header.Key, header.Value);
+        });        
         xhr.responseType = 'blob';
         xhr.timeout = that.Settings.timeout;
 

--- a/www/download.js
+++ b/www/download.js
@@ -6,7 +6,8 @@ function Download() {
         folder: "folder",
         unzip: false,
         remove: false,
-        timeout: 0
+        timeout: 0,
+        headers: {}
     };
 }
 
@@ -37,6 +38,10 @@ Download.prototype.Initialize = function(settings) {
 
     if(typeof settings.timeout !== "undefined") {
         this.Settings.timeout = settings.timeout;
+    }
+    
+    if(typeof settings.headers !== "undefined") {
+        this.Settings.headers = settings.headers;
     }
 
     if(typeof settings.success !== "undefined") {
@@ -76,6 +81,7 @@ Download.prototype.Get = function(url) {
 
         var xhr = new XMLHttpRequest();
         xhr.open('GET', url, true);
+        xhr.setRequestHeader('Authorization', that.Settings.headers.Authorization);
         xhr.responseType = 'blob';
         xhr.timeout = that.Settings.timeout;
 


### PR DESCRIPTION
Add option to allow for xhr headers.

This is useful if you are trying to download files for an API with basic auth or there are extra headers you would like to send with your request.